### PR TITLE
Pass the extra ctags arguments properly

### DIFF
--- a/lib/tag-generator.js
+++ b/lib/tag-generator.js
@@ -16,7 +16,7 @@ export default class TagGenerator {
     const extraCommandArguments =
       atom.config.get('symbols-view-plus.plusConfigurations.extraCommandArguments');
     if (extraCommandArguments != '') {
-      this.args.push(extraCommandArguments);
+      this.args.push(...extraCommandArguments.split(' '));
     }
 
     this.args.push('--fields=+K');


### PR DESCRIPTION
We have to split and the provided args when user provides multiple of them
