### PR TITLE
Support toggling with selected text of active editor

### DIFF
--- a/lib/file-view.js
+++ b/lib/file-view.js
@@ -112,11 +112,13 @@ export default class FileView extends SymbolsView {
     const filePath = this.getPath();
     if (filePath) {
       const editor = this.getEditor();
+      const selectedText = editor.getSelectedText();
+
       if (atom.config.get('symbols-view-plus.originalConfigurations.quickJumpToFileSymbol') && editor) {
         this.initialState = this.serializeEditorState(editor);
       }
       this.populate(filePath);
-      this.attach();
+      this.attach(selectedText);
 
       // Store the editor for Dock theme
       if (this.theme == 'dock') {

--- a/lib/project-view.js
+++ b/lib/project-view.js
@@ -24,15 +24,18 @@ export default class ProjectView extends SymbolsView {
   }
 
   toggle() {
+    const editor = atom.workspace.getActiveTextEditor();
+    const selectedText = editor? editor.getSelectedText() : null;
+
     if (this.theme == 'dock') {
       this.populate();
-      this.attach();
+      this.attach(selectedText);
     } else {
       if (this.panel.isVisible()) {
         this.cancel();
       } else {
         this.populate();
-        this.attach();
+        this.attach(selectedText);
       }
     }
   }

--- a/lib/symbols-view.js
+++ b/lib/symbols-view.js
@@ -255,7 +255,7 @@ export default class SymbolsView {
     }
   }
 
-  async attach() {
+  async attach(query) {
     this.previouslyFocusedElement = document.activeElement;
 
     if (this.theme == 'dock') {
@@ -265,6 +265,9 @@ export default class SymbolsView {
     }
 
     this.selectListView.reset();
+    if (query) {
+        this.selectListView.update({query: query});
+    }
     this.selectListView.focus();
   }
 


### PR DESCRIPTION
### Description of the Change

For user-friendliness, this patch populates the atom-select-list with the selected text of the active text editor. This helps to look for the same symbol that appears multiple times on the same file (e.g. a method defined in multiple classes extending the same interface).

Note, we have to get the selected text before we initiate the jump to the symbol (i.e. `quickJumpToFileSymbol` is set).
